### PR TITLE
Fixed typo on message_dict

### DIFF
--- a/02-storing_our_messages_in_a_dict/run.py
+++ b/02-storing_our_messages_in_a_dict/run.py
@@ -9,7 +9,7 @@ messages = []
 def add_messages(username, message):
     """Add messages to the `messages` list"""
     now = datetime.now().strftime("%H:%M:%S")
-    messages_dict = {"timestamp": now, "from": username, "message": message}
+    message_dict = {"timestamp": now, "from": username, "message": message}
     messages.append(message_dict)
 
 


### PR DESCRIPTION
Hi there, while following the video for this lesson, I noticed a typo, as the dictionary's name "message_dict" is written as "messages_dict" but then passed as an argument as "message_dict" (without the "s"), this caused me errors and I think it's worth changing :)

Cheers!